### PR TITLE
Feat/login logout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 .vscode/
 
 http-client.env.json
+
+application-test.properties

--- a/FeedPrep_API.http
+++ b/FeedPrep_API.http
@@ -5,10 +5,23 @@ Content-Type: application/json
 
 {
   "name": "윤경모",
-  "email": "userf123@naver.com",
+  "email": "user123@naver.com",
   "password": "asdasdjkDF23",
   "role": "STUDENT"
 }
+
+### 유저 로그인
+POST localhost:8080/auth/login
+Content-Type: application/json
+
+{
+  "email": "user123@naver.com",
+  "password": "asdasdjkDF23"
+}
+
+> {%
+    client.global.set("accessToken", response.body.data.accessToken)
+%}
 
 ### 튜터 회원가입
 POST localhost:8080/auth/signup
@@ -16,10 +29,23 @@ Content-Type: application/json
 
 {
   "name": "윤경모",
-  "email": "userf123@naver.com",
+  "email": "tutor123@naver.com",
   "password": "asdasdjkDF23",
   "role": "TUTOR"
 }
+
+### 튜터 로그인
+POST localhost:8080/auth/login
+Content-Type: application/json
+
+{
+  "email": "tutor123@naver.com",
+  "password": "asdasdjkDF23"
+}
+
+> {%
+    client.global.set("accessToken", response.body.data.accessToken)
+%}
 
 ### 관리자 회원가입
 POST localhost:8080/admin/signup
@@ -27,15 +53,15 @@ Content-Type: application/json
 
 {
   "name": "윤경모",
-  "email": "adminf123@naver.com",
+  "email": "admin123@naver.com",
   "password": "asdasdjkDF23",
   "role": "ADMIN",
-  "secretCode": "{{JWT_SECRET_KEY}}"
+  "secretCode": "7JWI64WV7ZWY7IS47JqUIOyggO2drOuKlCDst6jspIDsg50g7Luk666k64uI7YuwIO2UhOuhnOygne2KuOulvCDrp4zrk6Tqs6Ag7J6I7Iq164uI64ukLg==;"
 }
 
 ### 관리자 로그인
 
-POST localhost:8080/api/auth/login
+POST localhost:8080/admin/login
 Content-Type: application/json
 
 {
@@ -47,6 +73,6 @@ Content-Type: application/json
     client.global.set("accessToken", response.body.data.accessToken)
 %}
 
-
-
-
+### 로그아웃
+POST localhost:8080/auth/logout
+Authorization: Bearer {{accessToken}}

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
     implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
 
+    // H2
+    implementation 'com.h2database:h2'
+
     // S3
     implementation platform('software.amazon.awssdk:bom:2.20.90')
     implementation 'software.amazon.awssdk:s3:2.20.46'

--- a/src/main/java/com/example/feedprep/common/config/CacheConfig.java
+++ b/src/main/java/com/example/feedprep/common/config/CacheConfig.java
@@ -1,4 +1,20 @@
 package com.example.feedprep.common.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
 public class CacheConfig {
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+
+        // 키와 값 모두 String 직렬화 사용
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
 }

--- a/src/main/java/com/example/feedprep/common/constants/BusinessRuleConstants.java
+++ b/src/main/java/com/example/feedprep/common/constants/BusinessRuleConstants.java
@@ -1,4 +1,15 @@
 package com.example.feedprep.common.constants;
 
 public class BusinessRuleConstants {
+    // 액세스 토큰 만료 시간 : 1시간
+    public static final long ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60;
+
+    // 리프레쉬 토큰 만료 시간 : 일주일
+    public static final long REFRESH_TOKEN_EXPIRATION_TIME = 1000L * 60 * 60 * 24 * 7;
+
+    // 블랙리스트 접두사
+    public static final String BLACKLIST_PREFIX = "blacklist:";
+
+    // 토큰 접두사
+    public static final String BEARER_PREFIX = "Bearer ";
 }

--- a/src/main/java/com/example/feedprep/common/exception/base/CustomException.java
+++ b/src/main/java/com/example/feedprep/common/exception/base/CustomException.java
@@ -3,9 +3,10 @@ package com.example.feedprep.common.exception.base;
 import com.example.feedprep.common.exception.enums.ErrorCode;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
 
 @Getter
-public class CustomException extends RuntimeException {
+public class CustomException extends AuthenticationException {
 
   private final ErrorCode errorCode;
 

--- a/src/main/java/com/example/feedprep/common/exception/enums/ErrorCode.java
+++ b/src/main/java/com/example/feedprep/common/exception/enums/ErrorCode.java
@@ -11,12 +11,20 @@ public enum ErrorCode {
     // 잘못된 요청
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다." ),
 
+    // Forbidden
     INVALID_ROLE_REQUEST(HttpStatus.FORBIDDEN, "해당 역할로 가입할 수 없습니다."),
+    UNAUTHORIZED_ROLE_LOGIN(HttpStatus.FORBIDDEN, "요청하신 로그인 경로에서는 해당 역할의 계정으로 로그인할 수 없습니다."),
+    FORBIDDEN_LOGOUT_ATTEMPT(HttpStatus.FORBIDDEN, "다른 사용자의 로그아웃 요청은 허용되지 않습니다."),
 
     //인증
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 서명입니다."),
     INVALID_SECRET_CODE(HttpStatus.UNAUTHORIZED, "유효하지 않은 시크릿 코드입니다." ),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED,"이미 만료된 토큰입니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED,"지원하지 않는 토큰입니다."),
+
 
     // 구독
     CANNOT_SUBSCRIBE_SELF(HttpStatus.BAD_REQUEST, "자기 자신을 구독할 수 없습니다."),
@@ -26,9 +34,11 @@ public enum ErrorCode {
 
     // 유저 모듈 임시 에러 코드
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
 
     // 피드백 요청 생성
     // 사용자 인증 관련
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다. " ),
     UNAUTHORIZED_REQUESTER_ACCESS(HttpStatus.FORBIDDEN, "해당 요청을 수행할 권한이 없습니다."),
     TUTOR_NOT_FOUND(HttpStatus.NOT_FOUND, "튜터 정보를 찾을 수 없습니다."),
     INVALID_DOCUMENT(HttpStatus.NOT_FOUND, "존재하지 않는 문서입니다."),
@@ -45,7 +55,8 @@ public enum ErrorCode {
     // 일반 오류
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "피드백 처리 중 내부 오류가 발생했습니다."),
 
-    ;
+
+   ;
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/feedprep/common/exception/enums/SuccessCode.java
+++ b/src/main/java/com/example/feedprep/common/exception/enums/SuccessCode.java
@@ -8,9 +8,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SuccessCode {
 
-    // 회원가입 및 로그인 성공
+    // 회원가입 및 로그인 / 로그아웃 성공
     SIGNUP_SUCCESS(HttpStatus.CREATED,"회원가입에 성공하였습니다." ),
     LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공하였습니다."),
+    LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃에 성공하였습니다."),
 
     // 구독 모듈
     SUBSCRIBED(HttpStatus.CREATED, "구독하였습니다."),
@@ -19,7 +20,7 @@ public enum SuccessCode {
     SUBSCRIBER_LIST(HttpStatus.OK, "구독자 목록입니다."),
 
    //피드백 요청 취소 성공
-    OK_FEEDBACK_REQUEST_CANCELED(HttpStatus.OK, "정상적으로 취소 되었습니다.")
+    OK_FEEDBACK_REQUEST_CANCELED(HttpStatus.OK, "정상적으로 취소 되었습니다."),
 
     ;
 

--- a/src/main/java/com/example/feedprep/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/feedprep/common/security/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.feedprep.common.security.config;
 
 import com.example.feedprep.common.security.jwt.JwtFilter;
 import com.example.feedprep.common.security.jwt.JwtUtil;
+import com.example.feedprep.common.security.jwt.TokenBlacklistService;
 import com.example.feedprep.common.security.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -26,6 +27,7 @@ public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final CustomUserDetailsService userDetailsService;
+    private final TokenBlacklistService tokenBlacklistService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -51,7 +53,7 @@ public class SecurityConfig {
 
     @Bean
     public JwtFilter jwtFilter() {
-        return new JwtFilter(jwtUtil, userDetailsService);
+        return new JwtFilter(jwtUtil, userDetailsService,tokenBlacklistService);
     }
 
     @Bean

--- a/src/main/java/com/example/feedprep/common/security/dto/LoginRequestDto.java
+++ b/src/main/java/com/example/feedprep/common/security/dto/LoginRequestDto.java
@@ -1,4 +1,0 @@
-package com.example.feedprep.common.security.dto;
-
-public class LoginRequestDto {
-}

--- a/src/main/java/com/example/feedprep/common/security/dto/LoginResponseDto.java
+++ b/src/main/java/com/example/feedprep/common/security/dto/LoginResponseDto.java
@@ -1,4 +1,0 @@
-package com.example.feedprep.common.security.dto;
-
-public class LoginResponseDto {
-}

--- a/src/main/java/com/example/feedprep/common/security/jwt/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/feedprep/common/security/jwt/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,38 @@
+package com.example.feedprep.common.security.jwt;
+
+import com.example.feedprep.common.exception.base.CustomException;
+import com.example.feedprep.common.exception.enums.ErrorCode;
+import com.example.feedprep.common.response.ApiResponseDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ErrorCode errorCode = ErrorCode.UNAUTHORIZED; // 기본값
+
+        if (authException instanceof CustomException e) {
+            errorCode = e.getErrorCode();
+        }
+
+        ApiResponseDto<?> apiResponse = ApiResponseDto.fail(errorCode, request.getRequestURI());
+
+        String json = new ObjectMapper().writeValueAsString(apiResponse);
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/com/example/feedprep/common/security/jwt/JwtUtil.java
+++ b/src/main/java/com/example/feedprep/common/security/jwt/JwtUtil.java
@@ -1,28 +1,49 @@
 package com.example.feedprep.common.security.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import com.example.feedprep.common.exception.base.CustomException;
+import com.example.feedprep.common.exception.enums.ErrorCode;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Component;
+import com.example.feedprep.common.constants.BusinessRuleConstants;
+import org.springframework.util.StringUtils;
 
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
+
+import static com.example.feedprep.common.constants.BusinessRuleConstants.BEARER_PREFIX;
+import static com.example.feedprep.common.constants.BusinessRuleConstants.REFRESH_TOKEN_EXPIRATION_TIME;
 
 @Component
 public class JwtUtil {
     @Value("${jwt.secret.key}")
     private String secretKey;
 
-    private static final long EXPIRATION_TIME = 1000 * 60 * 60;
+    private SecretKey key;
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
 
     public String generateToken(String username, String role) {
         return Jwts.builder()
                 .setSubject(username)
                 .claim("role", role)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .setExpiration(new Date(System.currentTimeMillis() + BusinessRuleConstants.ACCESS_TOKEN_EXPIRATION_TIME))
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(String email) {
+        return Jwts.builder()
+                .setSubject(email) // 토큰 주체를 이메일로 설정
+                .setIssuedAt(new Date()) // 발급 시각
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION_TIME)) // 만료 시각
                 .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS256)
                 .compact();
     }
@@ -34,8 +55,38 @@ public class JwtUtil {
                     .build()
                     .parseClaimsJws(token)
                     .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(ErrorCode.EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            throw new CustomException(ErrorCode.UNSUPPORTED_TOKEN);
+        } catch (MalformedJwtException e) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
         } catch (JwtException e) {
-            return null;
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
+    }
+
+    // 토큰 앞의 "Bearer " 제거
+    public String substringToken(String tokenValue) {
+        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+            return tokenValue.substring(BEARER_PREFIX.length());
+        }
+        throw new CustomException(ErrorCode.MISSING_TOKEN);
+    }
+
+    // 토큰에서 Claims(정보) 추출
+    public Claims extractClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    // 남은 기간 반환 메서드
+    public long getRemainingMillis(Claims claims) {
+        long expirationTime = claims.getExpiration().getTime();
+        long now = System.currentTimeMillis();
+        return expirationTime - now;
     }
 }

--- a/src/main/java/com/example/feedprep/common/security/jwt/TokenBlacklistService.java
+++ b/src/main/java/com/example/feedprep/common/security/jwt/TokenBlacklistService.java
@@ -1,0 +1,42 @@
+package com.example.feedprep.common.security.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.example.feedprep.common.constants.BusinessRuleConstants.BLACKLIST_PREFIX;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TokenBlacklistService {
+    private final RedisTemplate<String,String> redisTemplate;
+
+    /**
+     * 토큰을 블랙리스트에 등록, 만료시간까지 보관
+     * @param token 토큰 문자열
+     * @param expirationMillis 남은 만료 시간 (ms)
+     */
+    public void addTokenToBlacklist(String token, long expirationMillis) {
+        String key = BLACKLIST_PREFIX + token;
+        redisTemplate.opsForValue().set(key, "logout", expirationMillis, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * 토큰이 블랙리스트에 존재하는지 확인
+     * @param token 토큰 문자열
+     * @return true면 블랙리스트에 등록된 상태
+     */
+    public boolean isTokenBlacklisted(String token) {
+        String key = BLACKLIST_PREFIX + token;
+        return redisTemplate.hasKey(key);
+    }
+
+
+
+
+
+}

--- a/src/main/java/com/example/feedprep/common/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/example/feedprep/common/security/service/CustomUserDetailsService.java
@@ -14,7 +14,7 @@ public class CustomUserDetailsService {
     private final UserRepository userRepository;
 
     public UserDetails loadUserByUsername(String email) {
-        User user = userRepository.getUserByNameOrElseThrow(email);
+        User user = userRepository.getUserByEmailOrElseThrow(email);
         return new CustomUserDetails(user);
     }
 }

--- a/src/main/java/com/example/feedprep/common/web/argument/AuthUserArgumentResolver.java
+++ b/src/main/java/com/example/feedprep/common/web/argument/AuthUserArgumentResolver.java
@@ -33,14 +33,12 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
     ) throws CustomException {
         // 1. 인증 객체 꺼내옴
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        // 2. 인증 객체가 비어 있거나  CustomUserDetails 타입이 아닐 경우
-        if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails userDetails)) {
-            AuthUser authUser = parameter.getParameterAnnotation(AuthUser.class);
-            if (authUser == null || authUser.required()) {
-                // 유효 하지 않은 토큰 예외 처리
-                throw new CustomException(ErrorCode.MISSING_TOKEN);
-            }
-            return null;
+        // 2. 인증 객체가 비어 있거나  CustomUserDetails 타입이 아닐 경우 예외 처리
+        if (authentication == null) {
+            throw new CustomException(ErrorCode.MISSING_TOKEN);
+        }
+        if (!(authentication.getPrincipal() instanceof CustomUserDetails userDetails)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
         // 유효할 경우 userId 반환
         return userDetails.getUser().getUserId();

--- a/src/main/java/com/example/feedprep/domain/auth/controller/AdminAuthController.java
+++ b/src/main/java/com/example/feedprep/domain/auth/controller/AdminAuthController.java
@@ -2,11 +2,10 @@ package com.example.feedprep.domain.auth.controller;
 
 import com.example.feedprep.common.exception.enums.SuccessCode;
 import com.example.feedprep.common.response.ApiResponseDto;
-import com.example.feedprep.domain.auth.dto.AdminSignupRequestDto;
-import com.example.feedprep.domain.auth.dto.SignupRequestDto;
-import com.example.feedprep.domain.auth.dto.SignupResponseDto;
+import com.example.feedprep.domain.auth.dto.*;
 import com.example.feedprep.domain.auth.service.AuthService;
 
+import com.example.feedprep.domain.user.enums.UserRole;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,16 +15,29 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Set;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin")
 public class AdminAuthController {
     private final AuthService authService;
 
+    // 관리자 회원 가입
     @PostMapping("/signup")
     ResponseEntity<ApiResponseDto<SignupResponseDto>> signup(@RequestBody @Valid AdminSignupRequestDto requestDto) {
         SignupResponseDto responseDto = authService.adminSignup(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponseDto.success(SuccessCode.SIGNUP_SUCCESS, responseDto));
+    }
+
+    // 관리자 로그인
+    @PostMapping("/login")
+    ResponseEntity<ApiResponseDto<TokenResponseDto>> login(@RequestBody @Valid LoginRequestDto requestDto) {
+        Set<String> allowedRoles = Set.of("ADMIN");
+        TokenResponseDto responseDto =  authService.login(requestDto, allowedRoles);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponseDto.success(SuccessCode.LOGIN_SUCCESS, responseDto));
     }
 }

--- a/src/main/java/com/example/feedprep/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/feedprep/domain/auth/controller/AuthController.java
@@ -1,34 +1,55 @@
 package com.example.feedprep.domain.auth.controller;
 
+import com.example.feedprep.common.exception.base.CustomException;
+import com.example.feedprep.common.exception.enums.ErrorCode;
 import com.example.feedprep.common.exception.enums.SuccessCode;
 import com.example.feedprep.common.response.ApiResponseDto;
-import com.example.feedprep.domain.auth.dto.SignupRequestDto;
-import com.example.feedprep.domain.auth.dto.SignupResponseDto;
+import com.example.feedprep.common.security.jwt.JwtUtil;
+import com.example.feedprep.domain.auth.dto.*;
 import com.example.feedprep.domain.auth.service.AuthService;
-import com.example.feedprep.domain.user.dto.UserResponseDto;
+import com.example.feedprep.domain.user.enums.UserRole;
+import io.jsonwebtoken.Claims;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.graphql.GraphQlProperties;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
+    private final JwtUtil jwtUtil;
     private final AuthService authService;
 
     // 일반 회원 가입
     @PostMapping("/signup")
     ResponseEntity<ApiResponseDto<SignupResponseDto>> signup(@RequestBody @Valid SignupRequestDto requestDto) {
-        SignupResponseDto responseDto =  authService.signup(requestDto);
+        SignupResponseDto responseDto = authService.signup(requestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponseDto.success(SuccessCode.SIGNUP_SUCCESS, responseDto));
+    }
+
+    // 일반 로그인
+    @PostMapping("/login")
+    ResponseEntity<ApiResponseDto<TokenResponseDto>> login(@RequestBody @Valid LoginRequestDto requestDto) {
+
+        Set<String> allowedRoles = Set.of("STUDENT", "PENDING_TUTOR");
+        TokenResponseDto responseDto = authService.login(requestDto, allowedRoles);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponseDto.success(SuccessCode.LOGIN_SUCCESS, responseDto));
+    }
+
+    // 로그아웃
+    @PostMapping("/logout")
+    ResponseEntity<ApiResponseDto<Void>> logout(@RequestHeader("Authorization") String authHeader) {
+        authService.logout(authHeader);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponseDto.success(SuccessCode.LOGOUT_SUCCESS));
     }
 
 

--- a/src/main/java/com/example/feedprep/domain/auth/dto/AccessTokenReponseDto.java
+++ b/src/main/java/com/example/feedprep/domain/auth/dto/AccessTokenReponseDto.java
@@ -1,4 +1,0 @@
-package com.example.feedprep.domain.auth.dto;
-
-public class AccessTokenReponseDto {
-}

--- a/src/main/java/com/example/feedprep/domain/auth/dto/LoginRequestDto.java
+++ b/src/main/java/com/example/feedprep/domain/auth/dto/LoginRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.feedprep.domain.auth.dto;
+
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LoginRequestDto {
+
+    private final String email;
+    private final String password;
+}

--- a/src/main/java/com/example/feedprep/domain/auth/dto/TokenResponseDto.java
+++ b/src/main/java/com/example/feedprep/domain/auth/dto/TokenResponseDto.java
@@ -1,0 +1,11 @@
+package com.example.feedprep.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenResponseDto {
+    private final String accessToken;
+    private final String refreshToken;
+}

--- a/src/main/java/com/example/feedprep/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/feedprep/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,29 @@
+package com.example.feedprep.domain.auth.entity;
+
+import com.example.feedprep.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@Table(name = "refresh_tokens")
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public RefreshToken(String token, User user) {
+        this.token = token;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/example/feedprep/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/feedprep/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.example.feedprep.domain.auth.repository;
+
+import com.example.feedprep.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    RefreshToken findByUser_UserId(Long userId);
+
+}

--- a/src/main/java/com/example/feedprep/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/feedprep/domain/auth/service/AuthService.java
@@ -1,13 +1,16 @@
 package com.example.feedprep.domain.auth.service;
 
-import com.example.feedprep.domain.auth.dto.AdminSignupRequestDto;
-import com.example.feedprep.domain.auth.dto.SignupRequestDto;
-import com.example.feedprep.domain.auth.dto.SignupResponseDto;
-import jakarta.validation.Valid;
+import com.example.feedprep.domain.auth.dto.*;
+
+import java.util.Set;
 
 public interface AuthService {
     SignupResponseDto signup(SignupRequestDto requestDto);
 
+    TokenResponseDto login(LoginRequestDto requestDto, Set<String> admin);
+
     SignupResponseDto adminSignup(AdminSignupRequestDto requestDto);
+
+    void logout(String authHeader);
 
 }

--- a/src/main/java/com/example/feedprep/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/feedprep/domain/auth/service/AuthServiceImpl.java
@@ -2,32 +2,53 @@ package com.example.feedprep.domain.auth.service;
 
 import com.example.feedprep.common.exception.base.CustomException;
 import com.example.feedprep.common.exception.enums.ErrorCode;
-import com.example.feedprep.domain.auth.dto.AdminSignupRequestDto;
-import com.example.feedprep.domain.auth.dto.SignupRequestDto;
-import com.example.feedprep.domain.auth.dto.SignupResponseDto;
+import com.example.feedprep.common.exception.enums.SuccessCode;
+import com.example.feedprep.common.response.ApiResponseDto;
+import com.example.feedprep.common.security.jwt.JwtUtil;
+import com.example.feedprep.common.security.jwt.TokenBlacklistService;
+import com.example.feedprep.domain.auth.dto.*;
+import com.example.feedprep.domain.auth.entity.RefreshToken;
+import com.example.feedprep.domain.auth.repository.RefreshTokenRepository;
 import com.example.feedprep.domain.user.entity.User;
 import com.example.feedprep.domain.user.enums.UserRole;
 import com.example.feedprep.domain.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+import java.util.Set;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class AuthServiceImpl implements AuthService{
+public class AuthServiceImpl implements AuthService {
 
+    private final JwtUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenBlacklistService tokenBlacklistService;
 
     @Value("${jwt.secret.key}")
     private String secretCode;
 
     @Override
     public SignupResponseDto signup(SignupRequestDto requestDto) {
+
+        Optional<User> user = userRepository.findByEmail(requestDto.getEmail());
+        if (user.isPresent()) {
+            throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
 
         String userRole = requestDto.getRole();
 
@@ -44,6 +65,10 @@ public class AuthServiceImpl implements AuthService{
 
     @Override
     public SignupResponseDto adminSignup(AdminSignupRequestDto requestDto) {
+        Optional<User> user = userRepository.findByEmail(requestDto.getEmail());
+        if (user.isPresent()) {
+            throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
 
         if (!requestDto.getSecretCode().equals(secretCode)) {
             throw new CustomException(ErrorCode.INVALID_SECRET_CODE);
@@ -54,11 +79,64 @@ public class AuthServiceImpl implements AuthService{
         // 대소문자 상관없이 사용자가 입력한 값에 따라 처리
         if (userRole.equalsIgnoreCase("ADMIN")) {
             userRole = "ADMIN";
-        }  else throw new CustomException(ErrorCode.INVALID_ROLE_REQUEST);
+        } else throw new CustomException(ErrorCode.INVALID_ROLE_REQUEST);
 
         UserRole finalRole = UserRole.valueOf(userRole);
         return createUser(requestDto.getName(), requestDto.getEmail(), requestDto.getPassword(), finalRole);
     }
+
+
+
+    @Override
+    public TokenResponseDto login(LoginRequestDto requestDto, Set<String> allowedRoles) {
+
+        User user = userRepository.getUserByEmailOrElseThrow(requestDto.getEmail());
+
+        RefreshToken existingRefreshToken = refreshTokenRepository.findByUser_UserId(user.getUserId());
+
+        // 특정 유저의 토큰이 이미 존재할 경우 서버에서 삭제
+        if (existingRefreshToken != null) {
+            refreshTokenRepository.delete(existingRefreshToken);
+        }
+
+        if (!allowedRoles.contains(user.getRole().name())) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ROLE_LOGIN);
+        }
+
+        if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String accessToken = jwtUtil.generateToken(user.getEmail(), user.getRole().name());
+        String refreshTokenString = jwtUtil.generateRefreshToken(user.getEmail());
+        RefreshToken refreshToken = new RefreshToken(refreshTokenString, user);
+
+        refreshTokenRepository.save(refreshToken);
+
+        return new TokenResponseDto(accessToken, refreshTokenString);
+
+    }
+
+    @Override
+    public void logout(String authHeader) {
+        // Bearer 제거
+        String accessToken = jwtUtil.substringToken(authHeader);
+
+        // Claims 추출 (유효성 검증)
+        Claims claims = jwtUtil.validateToken(accessToken);
+        if (claims == null) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        // 만료까지 남은 시간 계산 -> 해당 토큰 블랙 리스트 등록
+        long remainingMillis = jwtUtil.getRemainingMillis(claims);
+
+        if (remainingMillis > 0) {
+           tokenBlacklistService.addTokenToBlacklist(accessToken, remainingMillis);
+        }
+
+    }
+
 
     private SignupResponseDto createUser(String name, String email, String password, UserRole role) {
         String encodedPassword = passwordEncoder.encode(password);
@@ -66,5 +144,6 @@ public class AuthServiceImpl implements AuthService{
         userRepository.save(user);
         return SignupResponseDto.from(user);
     }
+
 
 }

--- a/src/main/java/com/example/feedprep/domain/document/entity/Document.java
+++ b/src/main/java/com/example/feedprep/domain/document/entity/Document.java
@@ -35,9 +35,8 @@ public class Document extends BaseTimeEntity {
     @Column(name = "file_url")
     private String fileUrl;
 
-
     public Document(User user, String fileUrl){
-        this.userId =  user;
+        this.user =  user;
         this.fileUrl = fileUrl;
     }
 }

--- a/src/main/java/com/example/feedprep/domain/feedback/entity/Feedback.java
+++ b/src/main/java/com/example/feedprep/domain/feedback/entity/Feedback.java
@@ -25,7 +25,6 @@ import com.example.feedprep.domain.user.entity.User;
 @RequiredArgsConstructor
 public class Feedback extends BaseTimeEntity{
 
-
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/example/feedprep/domain/user/entity/User.java
+++ b/src/main/java/com/example/feedprep/domain/user/entity/User.java
@@ -41,11 +41,11 @@ public class User extends BaseTimeEntity {
 
     private String password;
 
-    @Enumerated(EnumType.STRING)
     private String address;
 
     private String introduction;
 
+    @Enumerated(EnumType.STRING)
     private UserRole role;
 
     private Long point;

--- a/src/main/java/com/example/feedprep/domain/user/entity/User.java
+++ b/src/main/java/com/example/feedprep/domain/user/entity/User.java
@@ -2,12 +2,8 @@ package com.example.feedprep.domain.user.entity;
 
 import com.example.feedprep.common.entity.BaseTimeEntity;
 import com.example.feedprep.domain.user.enums.UserRole;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.sql.Timestamp;
 
 import lombok.AllArgsConstructor;
@@ -32,6 +28,7 @@ public class User extends BaseTimeEntity {
 
     private String password;
 
+    @Enumerated(EnumType.STRING)
     private UserRole role;
 
     private Long point;

--- a/src/main/java/com/example/feedprep/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/feedprep/domain/user/repository/UserRepository.java
@@ -6,6 +6,9 @@ import com.example.feedprep.domain.user.entity.User;
 import com.example.feedprep.domain.user.enums.UserRole;
 import com.example.feedprep.domain.user.enums.UserRole;
 import java.util.List;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,10 +20,10 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> getUserByName(String email);
+    Optional<User> getUserByEmail(String email);
 
-    default User getUserByNameOrElseThrow(String email) {
-        return getUserByName(email).orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
+    default User getUserByEmailOrElseThrow(String email) {
+        return getUserByEmail(email).orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 
 	//피드백 요청용 조회 문
@@ -36,4 +39,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
         );
         return user;
     }
+
+    Optional<User> findByEmail(String email);
 }


### PR DESCRIPTION
### 유저, 튜터, 관리자 로그인, 로그아웃 기능 구현

### 추가 사항

같은 이메일로 가입시 예외 처리 추가
- 인증 객체가 비어있거나 CustomUserDetails 타입이 아닐 경우 따로 예외 처리

필터 단위에서도 공통 응답 처리
- CustomException에서 RuntimeException 대신 AuthenticationException를 상속받도록 처리 (AuthenticationException 자체가 RuntimeException을 상속받음)
- CustomAuthenticationEntryPoint 구현

### 수정 사항

build.gradle에 h2 누락되어 있어서 추가
Document 엔티티에 this.userId = user; -> this.user = user; 수정

클래스 이름 자체는 FeedBack인데 실제로 정의된건 Feedback이라 
클래스 이름 Feedback으로 수정
